### PR TITLE
Don't paginate when listing hosts w/ notifications disabled.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nagiosharder (0.5.0.swiftype02)
+    nagiosharder (0.5.0.swiftype03)
       activesupport
       hashie (~> 1.2.0)
       httparty

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nagiosharder (0.5.0.swiftype03)
+    nagiosharder (0.5.0.swiftype04)
       activesupport
       hashie (~> 1.2.0)
       httparty

--- a/lib/nagiosharder.rb
+++ b/lib/nagiosharder.rb
@@ -83,7 +83,7 @@ class NagiosHarder
 
       post_command(request)
     end
-   
+
     def disable_notifications
       request = {
         :cmd_typ => COMMANDS[:disable_notifications]
@@ -154,7 +154,7 @@ class NagiosHarder
 
       post_command(request)
     end
-    
+
     def unacknowledge_service(host, service)
       request = {
         :cmd_typ => COMMANDS[:remove_service_acknowledgement],
@@ -167,7 +167,7 @@ class NagiosHarder
 
     def schedule_host_downtime(host, options = {})
       options[:type] ||= :fixed
-      
+
       request = {
         :cmd_typ => COMMANDS[:schedule_host_downtime],
         :com_author => options[:author] || "#{@user} via nagiosharder",
@@ -195,7 +195,7 @@ class NagiosHarder
 
       post_command(request)
     end
-    
+
     def schedule_service_downtime(host, service, options = {})
       options[:type] ||= :fixed
 
@@ -231,7 +231,7 @@ class NagiosHarder
         :cmd_typ => COMMANDS["del_#{downtime_type}".to_sym],
         :down_id => downtime_id
       }
-      
+
       post_command(request)
     end
 
@@ -242,7 +242,7 @@ class NagiosHarder
         :force_check => true,
         :cmd_typ => COMMANDS[:schedule_host_check],
       }
-      
+
       post_command(request)
     end
 
@@ -254,10 +254,10 @@ class NagiosHarder
         :force_check => true,
         :cmd_typ => COMMANDS[:schedule_service_check],
       }
-      
+
       post_command(request)
     end
-    
+
     def host_status(host)
       host_status_url = "#{status_url}?host=#{host}&embedded=1&noheader=1&limit=0"
       response = get(host_status_url)
@@ -356,18 +356,18 @@ class NagiosHarder
 
       servicegroups
     end
-    
+
     def hostgroups_detail(hostgroup = "all")
       hostgroups_detail_url = "#{status_url}?hostgroup=#{hostgroup}&style=hostdetail&embedded=1&noheader=1&limit=0"
       response = get(hostgroups_detail_url)
-      
+
       raise "wtf #{hostgroups_detail_url}? #{response.code}" unless response.code == 200
-      
+
       hosts = {}
       parse_detail_html(response) do |status|
         hosts[status[:host]] = status
       end
-      
+
       hosts
     end
 
@@ -444,10 +444,10 @@ class NagiosHarder
     def service_notifications_disabled?(host, service)
       self.host_status(host)[service].notifications_disabled
     end
-    
+
     def alert_history(options = {})
       params = {}
-    
+
       {
         :state_type => :history_state,
         :type => :history
@@ -456,7 +456,7 @@ class NagiosHarder
           params[key.to_s.gsub(/_/, '')] = Nagiosharder::Filters.value(val, *options[key])
         end
       end
-      
+
       # if any of the standard filter params are already integers, those win
       %w(
         :statetype,
@@ -464,12 +464,12 @@ class NagiosHarder
       ).each do |key|
         params[key.to_s] = options[:val] if !options[:val].nil? && options[:val].match(/^\d*$/)
       end
-      
+
       params['host'] = options[:host] || 'all'
       params['archive'] = options[:archive] || '0'
-      
+
       query = params.select {|k,v| v }.map {|k,v| "#{k}=#{v}" }.join('&')
-      
+
       alert_history_url = "#{history_url}?#{query}"
       puts alert_history_url
       response = get(alert_history_url)
@@ -495,7 +495,7 @@ class NagiosHarder
     def extinfo_url
       "#{nagios_url}/extinfo.cgi"
     end
-    
+
     def history_url
       "#{nagios_url}/history.cgi"
     end
@@ -552,21 +552,21 @@ class NagiosHarder
       counts['unknown'] = column.inner_text.match(/(\d+)\s(UNKNOWN)/)[1] rescue 0
       return link, counts
     end
-    
+
     def parse_detail_html(response)
       doc = Nokogiri::HTML(response.to_s)
       rows = doc.css('table.status > tr')
-      
+
       rows.each do |row|
         columns = Nokogiri::HTML(row.inner_html).css('body > td').to_a
         if columns.any?
 
           # Host column
           host = columns[0].css('a').text.strip
-          
+
           # Status
           status = columns[1].inner_html  if columns[1]
-          
+
           # Last Check
           last_check = if columns[2] && columns[2].inner_html != 'N/A'
                          last_check_str = columns[2].inner_html
@@ -590,10 +590,10 @@ class NagiosHarder
           # Status info
           status_info = columns[4].inner_html.gsub('&nbsp;', '').gsub("\302\240", '').gsub("&#160;", '') if columns[4]
           debug 'parsed status info column'
-          
+
           if host && status && last_check && duration && started_at && status_info
             host_extinfo_url = "#{extinfo_url}?type=1&host=#{host}"
-            
+
             status = Hashie::Mash.new :host => host,
               :status => status,
               :last_check => last_check,
@@ -729,11 +729,11 @@ class NagiosHarder
 
       nil
     end
-    
+
     def parse_history_html(response)
       doc = Nokogiri::HTML(response.to_s)
       alerts = doc.css('div.logEntries img')
-      
+
       if alerts.any?
         alerts.each do |row|
           text = row.next.text.gsub('  ',';').split(/;|: /) unless row.next.text.nil?
@@ -748,10 +748,10 @@ class NagiosHarder
             when text.length == 5 # scheduled host downtime
               last_check, alert_type, host, status, *extended_info = row.next.text.gsub('  ',';').split(/;|: /)
           end
-          
+
           service_extinfo_url = service ? "#{extinfo_url}?type=2&host=#{host}&service=#{CGI.escape(service)}" : nil
           host_extinfo_url = "#{extinfo_url}?type=1&host=#{host}"
-          
+
           alert = Hashie::Mash.new :last_check => last_check.gsub('[','').gsub(']',''),
             :alert_type => alert_type,
             :host => host,
@@ -762,7 +762,7 @@ class NagiosHarder
             :extended_info => extended_info.nil? ? extended_info : extended_info.join(': ').strip,
             :host_extinfo_url => host_extinfo_url,
             :service_extinfo_url => service_extinfo_url
-          
+
           yield alert
         end
       end

--- a/lib/nagiosharder.rb
+++ b/lib/nagiosharder.rb
@@ -113,7 +113,7 @@ class NagiosHarder
     end
 
     def hosts_which_notifications_disabled
-      response = get(status_url + '?hostgroup=all&style=hostdetail')
+      response = get(status_url + '?hostgroup=all&style=hostdetail&limit=0')
       response.scan(/.*ndisabled\.gif.*/).collect { |i| i.scan(/(?<=host\=)[^']*/)[0] }
     end
 

--- a/lib/nagiosharder/filters.rb
+++ b/lib/nagiosharder/filters.rb
@@ -56,8 +56,8 @@ module Nagiosharder
     NOTIFICATION_HOST_FLAP=4096
     NOTIFICATION_SERVICE_CUSTOM=8192
     NOTIFICATION_HOST_CUSTOM=16384
-    
-    
+
+
     #/********************** HOST AND SERVICE STATE TYPES **********************/
 
     HISTORY_STATE_ALL=0

--- a/nagiosharder.gemspec
+++ b/nagiosharder.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'nagiosharder'
-  s.version     = '0.5.0.swiftype03'
+  s.version     = '0.5.0.swiftype04'
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Josh Nichols', 'Jesse Newland', 'Travis Graham']

--- a/nagiosharder.gemspec
+++ b/nagiosharder.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'nagiosharder'
-  s.version     = '0.5.0.swiftype02'
+  s.version     = '0.5.0.swiftype03'
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Josh Nichols', 'Jesse Newland', 'Travis Graham']


### PR DESCRIPTION
## https://github.com/elastic/search-developer-productivity/issues/238

This adds the request parameter `limit=0` to the list of hosts we parse when trying to find disabled notifications.